### PR TITLE
Add a modular file to source for jelos

### DIFF
--- a/PortMaster/mod_jelos.txt
+++ b/PortMaster/mod_jelos.txt
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## Modular - JELOS
+# 
+# A modular file that is sourced for specific script lines required by ports running on JELOS.
+#
+# usage `source <path_to>/mod_jelos.txt`
+
+
+export SPA_PLUGIN_DIR="/usr/lib32/spa-0.2"
+export PIPEWIRE_MODULE_DIR="/usr/lib32/pipewire-0.3/"


### PR DESCRIPTION
This creates a file `mod_jelos.txt` that can be sourced for specific script lines required by ports running on JELOS. By being modular, this removed the need for each start script to have several lines changed whenever JELOS does something...magical.

Recommend creating an official port template for new ports to use that has this set up already.