### PR TITLE
Fix aarch64 ports on JELOS.

### DIFF
--- a/PortMaster/mod_JELOS.txt
+++ b/PortMaster/mod_JELOS.txt
@@ -10,4 +10,4 @@
 export SPA_PLUGIN_DIR="/usr/lib32/spa-0.2"
 export PIPEWIRE_MODULE_DIR="/usr/lib32/pipewire-0.3/"
 
-export LIBGL_DRIVERS_PATH=/usr/lib32/dri
+export LIBGL_DRIVERS_PATH=/usr/lib32/dri:/usr/lib/dri


### PR DESCRIPTION
Previously LIBGL_DRIVERS_PATH would override the path to the DRI drivers causing only armhf to be successfully loaded. This commit fixes this issue.