### PR TITLE
Set lowercase for RetroDECK

### DIFF
--- a/PortMaster/pylibs/harbourmaster/hardware.py
+++ b/PortMaster/pylibs/harbourmaster/hardware.py
@@ -113,7 +113,7 @@ HW_INFO = {
 
     # Computer/Testing
     "pc":        {"resolution": (640, 480), "analogsticks": 2, "cpu": "unknown", "capabilities": ["opengl", "power"]},
-    "RetroDECK": {"resolution": (1280, 720), "analogsticks": 2, "cpu": "x86_64", "capabilities": ["opengl", "power"]},
+    "retrodeck": {"resolution": (1280, 720), "analogsticks": 2, "cpu": "x86_64", "capabilities": ["opengl", "power"]},
 
     # Default
     "default":   {"resolution": (640, 480), "analogsticks": 2, "cpu": "unknown", "capabilities": ["opengl", "power"]},


### PR DESCRIPTION
Has there been a change to selecting device names by lowercase?

This fixes RetroDECK not getting picked up as a device anymore