### PR TITLE
Fix info about rgb10max3

### DIFF
--- a/PortMaster/pylibs/harbourmaster/hardware.py
+++ b/PortMaster/pylibs/harbourmaster/hardware.py
@@ -43,6 +43,7 @@ DEVICES = {
     "Powkiddy RGB30":  {"device": "rgb30",  "manufacturer": "Powkiddy",  "cfw": ["ArkOS", "JELOS", "ROCKNIX"]},
     "Powkiddy RK2023": {"device": "rk2023", "manufacturer": "Powkiddy",  "cfw": ["ArkOS", "JELOS", "ROCKNIX"]},
     "Powkiddy X55":    {"device": "x55",    "manufacturer": "Powkiddy",  "cfw": ["JELOS"]},
+    "Powkiddy RGB10MAX3": {"device": "rgb10max3", "manufacturer": "Powkiddy",  "cfw": ["JELOS", "ROCKNIX"]},
 
     # Hardkernel
     "Hardkernel ODROID GO Advance": {"device": "oga", "manufacturer": "Hardkernel",  "cfw": ["ArkOS", "AmberELEC", "EmuELEC", "JELOS", "ROCKNIX"]},
@@ -89,7 +90,8 @@ HW_INFO = {
 
     # Powkiddy
     "x55":       {"resolution": (1280, 720), "analogsticks": 2, "cpu": "rk3566", "capabilities": ["power"], "ram": 2048},
-    "rgb10max3": {"resolution": ( 854, 480), "analogsticks": 2, "cpu": "s922x",  "capabilities": ["power"], "ram": 2048},
+    "rgb10max3": {"resolution": (1280, 480), "analogsticks": 2, "cpu": "rk3566",  "capabilities": ["power"], "ram": 1024},
+    "rgb10max3pro": {"resolution": ( 854, 480), "analogsticks": 2, "cpu": "s922x",  "capabilities": ["power"], "ram": 2048},
     "rgb10max2": {"resolution": ( 854, 480), "analogsticks": 2, "cpu": "rk3326", "capabilities": [], "ram": 1024},
     "rgb10max":  {"resolution": ( 854, 480), "analogsticks": 2, "cpu": "rk3326", "capabilities": [], "ram": 1024},
     "rgb10s":    {"resolution": ( 480, 320), "analogsticks": 1, "cpu": "rk3326", "capabilities": [], "ram": 1024},


### PR DESCRIPTION
Fixed info about rgb10max3. It was missing in devices and there was info about pro model