### PR TITLE
Add virtual screen script

### DIFF
--- a/PortMaster/control.txt
+++ b/PortMaster/control.txt
@@ -158,3 +158,10 @@ if [ -f "$controlfolder/cwtbe_flag" ]; then
 else
   GPTOKEYB="$ESUDO $controlfolder/gptokeyb $ESUDOKILL"
 fi
+
+# Set current virtual screen
+if [ "$CFW_NAME" == "muOS" ]; then
+  /opt/muos/extra/muxlog & CUR_TTY="/tmp/muxlog_info"
+else
+    CUR_TTY="/dev/tty0"
+fi


### PR DESCRIPTION
Adds a virtual screen script to the end of `control.txt` so ports can just use `$CUR_TTY` and have virtual screen support on muos, and can easily add other CFWs as needed.