### PR TITLE
Remove the use of -q option for umount in the bind_directories function

### DIFF
--- a/PortMaster/funcs.txt
+++ b/PortMaster/funcs.txt
@@ -39,7 +39,7 @@ bind_directories() {
     if [ "$PM_CAN_MOUNT" = "Y" ]; then
         [[ -L "$1" ]] && rm -f "$1"
         mkdir -p "$1"
-        $ESUDO umount -q "$1"
+        $ESUDO umount "$1"
         $ESUDO mount --bind "$2" "$1"
     else
         # RetroDECK cant use bind mount without root.


### PR DESCRIPTION
The `-q` option for `umount` is not supported in busybox (on rocknix at least):

```
umount: invalid option -- 'q'
BusyBox v1.36.1 (2024-08-11 13:38:01 UTC) multi-call binary.

Usage: umount [-rlfda] [-t FSTYPE] FILESYSTEM|DIRECTORY

Unmount filesystems

    -a    Unmount all filesystems
    -r    Remount devices read-only if mount is busy
    -l    Lazy umount (detach filesystem)
    -f    Force umount (i.e., unreachable NFS server)
    -d    Free loop device if it has been used
    -t FSTYPE[,...]    Unmount only these filesystem type(s)
```

It ends up in duplicated mounts after running the same game several time until the device is restarted.

The solution is to remove the use of the `-q` option (quiet mode), which should do ok and just generate this message in the log when the game starts for the first time after a reboot:
`umount: can't unmount /storage/.ohrrpgce: Invalid argument`

Here is the help of the system `umount` command for information:

```
umount -h

Usage:
 umount [-hV]
 umount -a [options]
 umount [options] <source> | <directory>

Unmount filesystems.

Options:
 -a, --all               unmount all filesystems
 -A, --all-targets       unmount all mountpoints for the given device in the
                           current namespace
 -c, --no-canonicalize   don't canonicalize paths
 -d, --detach-loop       if mounted loop device, also free this loop device
     --fake              dry run; skip the umount(2) syscall
 -f, --force             force unmount (in case of an unreachable NFS system)
 -i, --internal-only     don't call the umount.<type> helpers
 -n, --no-mtab           don't write to /etc/mtab
 -l, --lazy              detach the filesystem now, clean up things later
 -O, --test-opts <list>  limit the set of filesystems (use with -a)
 -R, --recursive         recursively unmount a target with all its children
 -r, --read-only         in case unmounting fails, try to remount read-only
 -t, --types <list>      limit the set of filesystem types
 -v, --verbose           say what is being done
 -q, --quiet             suppress 'not mounted' error messages
 -N, --namespace <ns>    perform umount in another namespace

 -h, --help              display this help
 -V, --version           display version

For more details see umount(8).
```

For history, the discussion is in discord [here](https://discord.com/channels/1122861252088172575/1125360412825755738/1295837972796674202)