### PR TITLE
Align symlink with mount bind logic in the bind_directories function

### DIFF
--- a/PortMaster/funcs.txt
+++ b/PortMaster/funcs.txt
@@ -31,7 +31,7 @@ fi
 
 
 bind_directories() {
-    # Usage: bind_directories $GAMEDIR/savedata ~/.config/StardewValley
+    # Usage: bind_directories ~/.config/StardewValley $GAMEDIR/savedata
     # 
     # Reason: some platforms (batocera) use exfat for the home directory, so we can't use symbolic links
     # We then instead use bind mount, however retrodeck cannot bind mount because it does not run in root.
@@ -43,8 +43,8 @@ bind_directories() {
         $ESUDO mount --bind "$2" "$1"
     else
         # RetroDECK cant use bind mount without root.
-        rm -rf "$2"
-        ln -sfv "$1" "$2"
+        rm -f "$1"
+        ln -sfv "$2" "$1"
     fi
 }
 


### PR DESCRIPTION
The new bind_directories function doesn't work in the two methods (bind mount vs. symlink) the same way. The logic must be aligned. As we have mainly made it work on  `[ "$PM_CAN_MOUNT" = "Y" ]` CFW I've chosen to adapt the symlink method rather than the mount bind which will requires to update the ports already deployed.

Here are some exemples to better understand what's going on :)

```
[~/.config]# ls -l
total 28
lrwxrwxrwx    1 root     root            46 Oct 16 23:17 Blossom Tales 2 -> //mnt/mmc/ports/blossomtales2/savedata/windows
drwxr-xr-x    3 root     root          4096 Oct 16 10:56 btop
drwxr-xr-x    5 root     root          4096 Sep 25 07:57 fish
drwxr-xr-x    2 root     root          4096 Oct 17 10:11 htop
drwxr-xr-x    4 root     root          4096 Sep  3 07:27 micro
drwxr-xr-x    2 root     root          4096 Oct 16 17:05 pulse
drwxr-xr-x    2 root     root          4096 Oct 23 14:13 rednukem
drwxr-xr-x   21 root     root          4096 Oct 16 23:14 retroarch
[~/.config]# ls -l rednukem/
total 0
[~/.config]# mount --bind rednukem /mnt/mmc/ports/rednukem-dn3d-atomic/conf/rednukem # WRONG WAY
[~/.config]# ls -l rednukem/
total 0
[~/.config]# ls -l /mnt/mmc/ports/rednukem-dn3d-atomic/conf/rednukem
total 0
[~/.config]# umount /mnt/mmc/ports/rednukem-dn3d-atomic/conf/rednukem
[~/.config]# mount --bind /mnt/mmc/ports/rednukem-dn3d-atomic/conf/rednukem rednukem # GOOD WAY
[~/.config]# ls -l rednukem/
total 384
-rwxrwxrwx    1 root     root            43 Oct 23 14:08 grpfiles.cache
-rwxrwxrwx    1 root     root          1955 Oct 23 14:08 rednukem.cfg
-rwxrwxrwx    1 root     root          2625 Oct 23 13:43 settings.cfg
[~/.config]# ls -l /mnt/mmc/ports/rednukem-dn3d-atomic/conf/rednukem
total 384
-rwxrwxrwx    1 root     root            43 Oct 23 14:08 grpfiles.cache
-rwxrwxrwx    1 root     root          1955 Oct 23 14:08 rednukem.cfg
-rwxrwxrwx    1 root     root          2625 Oct 23 13:43 settings.cfg
[~/.config]# umount rednukem
[~/.config]# rm -r rednukem # REMOVING DIRECTORY FOR TESTING THE SYMLINK
[~/.config]# ln -s /mnt/mmc/ports/rednukem-dn3d-atomic/conf/rednukem rednukem # OBVIOUSLY THE GOOD WAY
[~/.config]# ls -l
total 24
lrwxrwxrwx    1 root     root            46 Oct 16 23:17 Blossom Tales 2 -> //mnt/mmc/ports/blossomtales2/savedata/windows
drwxr-xr-x    3 root     root          4096 Oct 16 10:56 btop
drwxr-xr-x    5 root     root          4096 Sep 25 07:57 fish
drwxr-xr-x    2 root     root          4096 Oct 17 10:11 htop
drwxr-xr-x    4 root     root          4096 Sep  3 07:27 micro
drwxr-xr-x    2 root     root          4096 Oct 16 17:05 pulse
lrwxrwxrwx    1 root     root            49 Oct 23 14:24 rednukem -> /mnt/mmc/ports/rednukem-dn3d-atomic/conf/rednukem
drwxr-xr-x   21 root     root          4096 Oct 16 23:14 retroarch
[~/.config]# ls -l rednukem/
total 384
-rwxrwxrwx    1 root     root            43 Oct 23 14:08 grpfiles.cache
-rwxrwxrwx    1 root     root          1955 Oct 23 14:08 rednukem.cfg
-rwxrwxrwx    1 root     root          2625 Oct 23 13:43 settings.cfg
[~/.config]#
```