### PR TITLE
muOS: remove dead joystick on devices without sticks

### DIFF
--- a/PortMaster/muos/control.txt
+++ b/PortMaster/muos/control.txt
@@ -39,6 +39,7 @@ get_controls() {
 
   if [[ "$(cat /opt/muos/config/device.txt)" == "RG35XX-PLUS" ]] || [[ "$(cat /opt/muos/config/device.txt)" == "RG35XX-SP" ]] || [[ "$(cat /opt/muos/config/device.txt)" == "RG28XX" ]]; then
     ANALOGSTICKS=0
+    sed -i 's/leftx:a0,lefty:a1,leftstick:a2,//g' "/tmp/gamecontrollerdb.txt"
   fi
 
   sdl_controllerconfig="$(< "/tmp/gamecontrollerdb.txt")"


### PR DESCRIPTION
This fixes a bug affecting TheXTech where the game doesn't allow input rebinding