### PR TITLE
Add weston ES_NAME support for ROCKNIX

### DIFF
--- a/PortMaster/PortMaster.sh
+++ b/PortMaster/PortMaster.sh
@@ -119,6 +119,9 @@ printf "\033c" > $CUR_TTY
 if [ -f "${controlfolder}/.emustation-refresh" ]; then
   $ESUDO rm -f "${controlfolder}/.emustation-refresh"
   $ESUDO systemctl restart emustation
+elif [ -f "${controlfolder}/.weston-refresh" ]; then
+  $ESUDO rm -f "${controlfolder}/.weston-refresh"
+  $ESUDO systemctl restart ${UI_SERVICE}
 elif [ -f "${controlfolder}/.emulationstation-refresh" ]; then
   $ESUDO rm -f "${controlfolder}/.emulationstation-refresh"
   $ESUDO systemctl restart emulationstation

--- a/PortMaster/pylibs/harbourmaster/platform.py
+++ b/PortMaster/pylibs/harbourmaster/platform.py
@@ -346,7 +346,6 @@ class PlatformJELOS(PlatformBase):
 
 
 class PlatformROCKNIX(PlatformJELOS):
-    ...
     ES_NAME = 'weston'
 
 

--- a/PortMaster/pylibs/harbourmaster/platform.py
+++ b/PortMaster/pylibs/harbourmaster/platform.py
@@ -347,6 +347,7 @@ class PlatformJELOS(PlatformBase):
 
 class PlatformROCKNIX(PlatformJELOS):
     ...
+    ES_NAME = 'weston'
 
 
 class PlatformBatocera(PlatformBase):


### PR DESCRIPTION
Fix the weird behaviour on the RP mini with Rocknix when PM-GUI exit after the installation of a new port.