### PR TITLE
Fixes to the do_release bash and Python scripts

### DIFF
--- a/do_release.sh
+++ b/do_release.sh
@@ -132,6 +132,10 @@ if [[ "$1" == "stable" ]] || [ "$MAKE_INSTALL" = "Y" ]; then
     rm -fRv pm_release
 fi
 
+if [[ ! -f "version.json" ]]; then
+    wget "https://github.com/PortsMaster/PortMaster-GUI/releases/latest/download/version.json"
+fi
+
 python3 tools/pm_version.py $*
 
 # Restore this file

--- a/tools/pm_release.py
+++ b/tools/pm_release.py
@@ -76,10 +76,10 @@ def main(argv):
 
     pugwash_data = load_info("PortMaster/pugwash")
 
-    print(f"{pugwash_data["version"]} now {version_number}")
+    print(f"{pugwash_data['version']} now {version_number}")
 
     pugwash_data["all_data"][pugwash_data["version_line"]] = \
-        f"{pugwash_data["version_text"]} = '{version_number}'"
+        f"{pugwash_data['version_text']} = '{version_number}'"
 
     if pugwash_data["release"]:
         pugwash_data["all_data"][pugwash_data["release_line"]] = \

--- a/tools/pm_release.py
+++ b/tools/pm_release.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import datetime
-import os
 import sys
 
 
@@ -64,11 +63,11 @@ def dump_info(main_file, info_data):
 def main(argv):
     if len(argv) == 1:
         release_type = "alpha"
-        version_number = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d-%H%M")
+        version_number = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d-%H%M")
 
     elif len(argv) == 2:
         release_type = argv[1]
-        version_number = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d-%H%M")
+        version_number = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d-%H%M")
 
     else:
         release_type = argv[1]

--- a/tools/pm_version.py
+++ b/tools/pm_version.py
@@ -3,7 +3,6 @@
 import datetime
 import hashlib
 import json
-import os
 import sys
 
 
@@ -30,11 +29,11 @@ def main(argv):
 
     if len(argv) == 1:
         release_type = "alpha"
-        version_number = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d-%H%M")
+        version_number = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d-%H%M")
 
     elif len(argv) == 2:
         release_type = argv[1]
-        version_number = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d-%H%M")
+        version_number = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d-%H%M")
 
     else:
         release_type = argv[1]


### PR DESCRIPTION
The `DEVELOPING.md` file suggested running the `./do_release.sh` script, but I ran into a few issues running it. This PR solves them so the script can run to completion.

- `pm_release.py`: Use single quotes for dict indexation inside of f-string. Using double quotes would close the f-string early causing a syntax error
- `pm_release/version.py`: Use `datetime.timezone.utc` instead of datetime.UTC for compatibility to Python<3.11. the  `datetime.UTC` alias was introduced in Python 3.11, see https://docs.python.org/3/library/datetime.html\#datetime.UTC
- `do_release.sh`: download `version.json` if missing. `pm_version.py` requires the `version.json` file, so we download it before running the script