### PR TITLE
fix faulty override logic

### DIFF
--- a/PortMaster/funcs.txt
+++ b/PortMaster/funcs.txt
@@ -101,7 +101,7 @@ pm_begin_splash() {
         PM_SPLASH_QUIT_MODE=""
     fi
 
-    if [ ! -z "$PM_SPLASH_THEME" ]; then
+    if [ -z "$PM_SPLASH_THEME" ]; then
         PM_SPLASH_THEME="$PM_RESOURCE_DIR/splash.ini"
     fi
 


### PR DESCRIPTION
function is documented as 'override by setting `$PM_SPLASH_THEME`' but was setting it when `test ! -z "$PM_SPLASH_THEME"` meaning it would only get set if it was not zero; i.e. already set.