### PR TITLE
Fixed squashfs runtime mounts not working on Crossmix

### DIFF
--- a/PortMaster/mod_TrimUI.txt
+++ b/PortMaster/mod_TrimUI.txt
@@ -18,6 +18,10 @@ GODOT2_OPTS="-r ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT} -f"
 # Use for Godot 3+
 GODOT_OPTS="--resolution ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT} -f"
 
+# Fix squashfs runtime mounts
+[ ! -d "/mnt/SDCARD/Data/home" ] && mkdir "/mnt/SDCARD/Data/home"
+export HOME="/mnt/SDCARD/Data/home"
+
 pm_platform_helper() {
     # DO SOMETHING HERE
     printf ""


### PR DESCRIPTION
Due to rootfs seemingly being immutable and a lack of $HOME which causes it to default to /, any port that uses a squashfs runtime would fail to mount it. This would cause the port to crash or behave erratically. This fix points $HOME to the SD card which is writable, and allows mounting squashfs runtimes.