### PR TITLE
Correct a typo in patcher

### DIFF
--- a/PortMaster/utils/patcher/main.lua
+++ b/PortMaster/utils/patcher/main.lua
@@ -317,7 +317,7 @@ function love.update(dt)
                 if patchState == "complete" then
                     PatchComplete()
                 elseif patchState == "failed" then
-                    patchFailed()
+                    PatchFailed()
                 elseif patchState == "cancelled" then
                     PatchCancelled()
                 end


### PR DESCRIPTION
A typo prevented `PatchFailed()` from being called correctly causing a love2d crash.