### PR TITLE
Change steam_news to port changelog

### DIFF
--- a/PortMaster/utils/patcher.txt
+++ b/PortMaster/utils/patcher.txt
@@ -7,13 +7,13 @@
 source $controlfolder/runtimes/"love_11.5"/love.txt
 
 # Check if we need to add news
-NEWS_FLAG=""
-if [ "$PATCHER_NEWS" = true ]; then
-  NEWS_FLAG="-n"
+CHANGELOG=""
+if [ "$CHANGELOG" = true ]; then
+  CHANGELOG="-n"
 fi
 
 # Run the patcher with exported args
 $GPTOKEYB "$LOVE_GPTK" &
-$LOVE_RUN "$controlfolder/utils/patcher" -f "$PATCHER_FILE" -g "$PATCHER_GAME" -t "$PATCHER_TIME" "$NEWS_FLAG"
+$LOVE_RUN "$controlfolder/utils/patcher" -f "$PATCHER_FILE" -g "$PATCHER_GAME" -t "$PATCHER_TIME" "$CHANGELOG"
 
 pm_gptokeyb_finish

--- a/PortMaster/utils/patcher/main.lua
+++ b/PortMaster/utils/patcher/main.lua
@@ -149,7 +149,7 @@ end
 -- Function to show the initial Talkies dialog with two messages
 function showInitialTalkiesDialog()
     if isNews then
-        Talkies.say("Cybion", "Hello! Cybion again! I found a new Steam news article for " .. gameName .. ".", {
+        Talkies.say("Cybion", "Hello! Cybion again! The port for " .. gameName .. " has an update!", {
             image = cybion,
             thickness = 2,
             oncomplete = function()
@@ -157,7 +157,7 @@ function showInitialTalkiesDialog()
                     image = cybion,
                     thickness = 2,
                     options = {
-                        {"View news", function() startPatchThread() end},
+                        {"View changelog", function() startPatchThread() end},
                         {"Continue", function() PatchCancelled() end}
                     }
                 })
@@ -182,7 +182,7 @@ end
 -- Function to show patch complete dialog
 function PatchComplete()
     if isNews then
-        Talkies.say("Cybion", "Thanks for reading! Now on to the game!", {
+        Talkies.say("Cybion", "Don't forget to update the port with the PortMaster App later. On with the game!", {
             thickness = 2,
             image = cybion,
             oncomplete = function()
@@ -218,7 +218,7 @@ function PatchCancelled()
         patchInProgress = false
         showOutput = false
     end
-    Talkies.say("Cybion", isNews and "News viewing canceled. On with the game!" or "Patching has been canceled. Please try again later.", {
+    Talkies.say("Cybion", isNews and "Don't forget to update the port with the PortMaster App later. On with the game!" or "Patching has been canceled. Please try again later.", {
         thickness = 2,
         image = cybion,
         oncomplete = function()

--- a/PortMaster/utils/patcher/patch_thread.lua
+++ b/PortMaster/utils/patcher/patch_thread.lua
@@ -4,122 +4,14 @@ local patchChannel = love.thread.getChannel("patch_output")  -- Channel for outp
 
 -- Function to execute the patching process
 local function runPatch()
-    local process = io.popen(patchScript)
-
-    -- Parsing state
-    local inList = false
-    local inQuote = false
-    local inCode = false
-    local inSpoiler = false
-    local lastWasContent = false
-    local skipLeadingBlanks = true -- Skip blanks until content
-
-    -- Cached list item prefix
-    local listItemPrefix = "  - "
-
-    -- Inline tag stripping (optimized for lists)
-    local function stripInlineTags(text)
-        if not text:match("%[.-%]") then return text end -- Skip if no tags
-        return text
-            :gsub("%[b%](.-)%[/b%]", "%1")
-            :gsub("%[i%](.-)%[/i%]", "%1")
-            :gsub("%[u%](.-)%[/u%]", "%1")
-            :gsub("%[strike%](.-)%[/strike%]", "%1")
-            :gsub("%[url=.-%](.-)%[/url%]", "%1")
-            :gsub("%[url%](.-)%[/url%]", "%1")
-            :gsub("%[img%].-%[/img%]", "")
-            :gsub("%[h1%](.-)%[/h1%]", "%1")
-            :gsub("%[color=.-%](.-)%[/color%]", "%1")
-            :gsub("%[size=.-%](.-)%[/size%]", "%1")
-            :gsub("%[%w+.-%]", "")
-            :gsub("%[/%w+%]", "")
-    end
+    local process = io.popen(patchScript)  
 
     while true do
         local line = process:read("*line")  -- Read output line by line
         if not line then
             break  -- Exit the loop if no more output
         end
-
-        local trimmed = line:match("^%s*(.-)%s*$") -- Trim whitespace
-
-        -- Skip empty lines until content
-        if trimmed == "" then
-            if not (inCode or inQuote or inSpoiler) and lastWasContent and not skipLeadingBlanks then
-                patchChannel:push("")
-                lastWasContent = false
-            end
-            goto continue
-        end
-
-        -- From here, we have non-empty content
-        skipLeadingBlanks = false
-
-        if inCode then
-            if trimmed:match("^%[/code%]") then
-                inCode = false
-                if lastWasContent then
-                    patchChannel:push("")
-                end
-                lastWasContent = false
-            else
-                patchChannel:push("  " .. trimmed)
-                lastWasContent = true
-            end
-        elseif inQuote then
-            if trimmed:match("^%[/quote%]") then
-                inQuote = false
-                if lastWasContent then
-                    patchChannel:push("")
-                end
-                lastWasContent = false
-            else
-                patchChannel:push("> " .. trimmed)
-                lastWasContent = true
-            end
-        elseif inSpoiler then
-            if trimmed:match("^%[/spoiler%]") then
-                inSpoiler = false
-                if lastWasContent then
-                    patchChannel:push("")
-                end
-                lastWasContent = false
-            else
-                patchChannel:push("(Spoiler) " .. trimmed)
-                lastWasContent = true
-            end
-        elseif trimmed:match("^%[list%]") then
-            inList = true
-        elseif trimmed:match("^%[/list%]") then
-            inList = false
-            if lastWasContent then
-                patchChannel:push("")
-            end
-            lastWasContent = false
-        elseif trimmed:match("^%[code%]") then
-            inCode = true
-        elseif trimmed:match("^%[quote.*%]") then
-            inQuote = true
-        elseif trimmed:match("^%[spoiler%]") then
-            inSpoiler = true
-        elseif trimmed:match("^%[%*%]") then
-            local item = trimmed:match("^%[%*%]%s*(.*)$") or ""
-            local processed = stripInlineTags(item)
-            if processed ~= "" then
-                patchChannel:push(listItemPrefix .. processed)
-                lastWasContent = true
-            end
-        else
-            -- Regular text or section header
-            local processed = stripInlineTags(trimmed)
-            if processed ~= "" then
-                local prefix = inList and "  " or ""
-                patchChannel:push(prefix .. processed)
-                lastWasContent = true
-            end
-        end
-
-        ::continue::
+        patchChannel:push(line)  -- Push the output to the channel
     end
 
     local exitCode = process:close() 

--- a/PortMaster/utils/scripts/changelog
+++ b/PortMaster/utils/scripts/changelog
@@ -3,7 +3,7 @@
 # Environment setup
 GAMEDIR="$PWD"
 PORTDIR=`basename "$PWD"`
-CACHEFILE="$GAMEDIR/tools/cache"
+CACHEFILE="$GAMEDIR/.cache"
 CHANGELOG_URL="https://raw.githubusercontent.com/PortsMaster/PortMaster-New/ports/$PORTDIR/$PORTDIR/changelog.md"
 MODE="$1"
 

--- a/PortMaster/utils/scripts/changelog
+++ b/PortMaster/utils/scripts/changelog
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+# Environment setup
+GAMEDIR="$PWD"
+PORTDIR=`basename "$PWD"`
+CACHEFILE="$GAMEDIR/tools/cache"
+CHANGELOG_URL="https://raw.githubusercontent.com/PortsMaster/PortMaster-New/ports/$PORTDIR/$PORTDIR/changelog.md"
+MODE="$1"
+
+# Check dependencies
+for cmd in curl awk; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: $cmd is required." >&2
+        return 1
+    fi
+done
+
+# Init variables
+response=""
+
+# Fetch changelog
+fetch_changelog() {
+    response=`curl -s -f --connect-timeout 10 "$CHANGELOG_URL" 2>/dev/null`
+    if [ $? -ne 0 ] || [ -z "$response" ]; then
+        echo "Error: Failed to fetch changelog from $CHANGELOG_URL" >&2
+        return 1
+    fi
+}
+
+# Extract and validate timestamp
+get_timestamp() {
+    # Use the passed argument if set, else fallback to $response
+    local changelog="${1:-$response}"
+
+    timestamp=$(echo "$changelog" | awk '/^# [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/ {print $2; exit}' | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+
+    if [ -z "$timestamp" ]; then
+        return 1  # fail if no timestamp found
+    fi
+    return 0
+}
+
+# Check cache and update logic
+check_cache() {
+    prev_time=""
+    if [ -s "$CACHEFILE" ]; then
+        prev_time=$(cat "$CACHEFILE")
+    fi
+
+    if ! fetch_changelog; then
+        CHANGELOG=false
+        return
+    fi
+
+    if ! get_timestamp "$response"; then
+        echo "Error: Could not extract timestamp from changelog" >&2
+        CHANGELOG=false
+        return
+    fi
+
+    if [ "$timestamp" != "$prev_time" ]; then
+        if ! echo "$timestamp" > "$CACHEFILE" || ! chmod 644 "$CACHEFILE"; then
+            echo "Error: Cannot write to $CACHEFILE" >&2
+            CHANGELOG=false
+            return
+        fi
+        CHANGELOG=true
+    else
+        CHANGELOG=false
+    fi
+}
+
+# Display changelog with delay
+display_changelog() {
+    if [ -z "$response" ]; then
+        fetch_changelog || return
+    fi
+
+    # Output with delay
+    echo "$response" | sed -e '$a\' | while IFS= read -r line; do
+        echo "$line"
+        sleep 1.5
+    done
+    
+    # Add a pause to give time to read the last of the content
+    i=0
+    while [ "$i" -lt 6 ]; do
+        echo
+        i=$((i + 1))
+        sleep 1
+    done
+}
+
+# Main logic
+check_cache
+export CHANGELOG
+
+# Exit early in check mode
+if [ "$MODE" = "check" ]; then
+    return
+fi
+
+display_changelog


### PR DESCRIPTION
Adapt the unused `steam_news` feature into `port_changelog`.

- Patcher GUI behaves differently if passed a specific flag on starting
- Source `changelog` script (placement can vary but for now placed in `utils/scripts`)
- Checks for `portdir/changelog.md` using rawgithubcontent url
- Offers to display changelog

Usage (place in launch script):
```bash
check_changelog() {
    # We don't want to check for changelog if the launchscript is too new
    SCR_PATH="$(readlink -f "$0")"
    MOD_TIME=$(stat -c %Y "$SCR_PATH")
    CURRENT_TIME=$(date +%s)
    AGE_DAYS=$(( (CURRENT_TIME - MOD_TIME) / 86400 ))
    if [ "$AGE_DAYS" -ge "3" ]; then
        # Source changelog
        source "$GAMEDIR/tools/changelog" check
        if [ "$CHANGELOG" = true ]; then
            export PATCHER_FILE="$controlfolder/utils/scripts/changelog"
            export PATCHER_GAME="$(basename "${0%.*}")"
            source "$controlfolder/utils/patcher.txt"
            $ESUDO kill -9 $(pidof gptokeyb)
        fi
    fi
}

# Check for a port update
check_changelog
```

`changelog.md` files **must be led with a proper YYYY-MM-DD date header** in order to be parsed by the script:

```md
# 2025-06-10
## Deltarune changelog:
- Use gmtoolkit runtime for utmt-cli texture compression
- Use gmtoolkit runtime for audio compression
- Use gmloadernext.aarch64 build with video to enable mp4 playback
- Use xbox360 virtual gamepad with export SteamDeck=1 to enable console-specific game code which would otherwise require a mouse and microphone
- Fix readme

## Known issues:
- A brief scene at the end of Chapter 3 and in some parts of Chapter 4 cause low framerates due to vram usage. These are short-lived scenes.

```