### PR TITLE
Updating the runtimes in the Full Installer

### DIFF
--- a/do_release.sh
+++ b/do_release.sh
@@ -73,14 +73,19 @@ zip -9r PortMaster.zip PortMaster/ \
     -x PortMaster/harbourmaster.txt \
     -x '*.DS_Store'
 
-if [ ! -f "runtimes.zip" ]; then
-    echo "Downloading Runtimes"
-    ./download_runtimes.sh   # This will create the runtimes folder and download files
+if [[ "$1" == "stable" ]] || [ "$MAKE_INSTALL" = "Y" ]; then
+echo "Creating Installers"
 
-    echo "Zipping runtimes"
-    zip -9r runtimes.zip runtimes
 
-    rm -rf runtimes
+    if [ ! -f "runtimes.zip" ]; then
+        echo "Downloading Runtimes"
+        ./download_runtimes.sh   # This will create the runtimes folder and download files
+
+        echo "Zipping runtimes"
+        zip -9r runtimes.zip runtimes
+
+        rm -rf runtimes
+    fi
 
 
     if [ ! -d "makeself-2.5.0" ]; then

--- a/do_release.sh
+++ b/do_release.sh
@@ -79,12 +79,12 @@ echo "Creating Installers"
 
     if [ ! -f "runtimes.zip" ]; then
         echo "Downloading Runtimes"
-        ./download_runtimes.sh   # This will create the runtimes folder and download files
-
-        echo "Zipping runtimes"
-        zip -9r runtimes.zip runtimes
-
-        rm -rf runtimes
+        mkdir -p runtimes
+        cd runtimes
+        ../tools/download_runtimes.sh
+        zip -9 ../runtimes.zip *
+        cd ..
+        rm -fRv runtimes
     fi
 
 

--- a/do_release.sh
+++ b/do_release.sh
@@ -73,37 +73,15 @@ zip -9r PortMaster.zip PortMaster/ \
     -x PortMaster/harbourmaster.txt \
     -x '*.DS_Store'
 
-if [[ "$1" == "stable" ]] || [ "$MAKE_INSTALL" = "Y" ]; then
-    echo "Creating Installers"
+if [ ! -f "runtimes.zip" ]; then
+    echo "Downloading Runtimes"
+    ./download_runtimes.sh   # This will create the runtimes folder and download files
 
-    if [ ! -f "runtimes.zip" ]; then
-        echo "Downloading Runtimes"
-        # Download the runtimes
-        mkdir -p runtimes
-        cd runtimes
-        for runtime_url in $(curl -s https://api.github.com/repos/PortsMaster/PortMaster-Runtime/releases/latest | grep browser_download_url | cut -d '"' -f 4); do
-            if [[ "$runtime_url" =~ /zulu11.*$ ]]; then
-                continue
-            fi
+    echo "Zipping runtimes"
+    zip -9r runtimes.zip runtimes
 
-            wget "$runtime_url"
-        done
+    rm -rf runtimes
 
-        # Validate them
-        for check_file in *.md5; do
-            runtime_file="${check_file/.md5/}"
-            if [[ $(md5sum "${runtime_file}" | cut -d ' ' -f 1) != $(cat "${check_file}" | cut -d ' ' -f 1) ]]; then
-                cd ..
-                rm -fRv runtimes
-                echo "Failed to validate runtime ${runtime_file}"
-                exit 255
-            fi
-        done
-
-        zip -9 ../runtimes.zip *
-        cd ..
-        rm -fRv runtimes
-    fi
 
     if [ ! -d "makeself-2.5.0" ]; then
         echo "Downloading makeself"

--- a/download_runtimes.sh
+++ b/download_runtimes.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Downloady of Fily
+if [ ! -f "ports.json" ]; then
+  curl -L -o ports.json $(curl -s https://api.github.com/repos/PortsMaster/PortMaster-New/releases/latest | jq -r '.assets[] | select(.name=="ports.json") | .browser_download_url')
+fi
+
+mkdir -p runtimes
+
+# i still dont understand how this works
+jq -r '
+  .utils
+  | to_entries
+  | map(select(
+      ( .key | ascii_downcase | contains("images") | not ) and
+      ( .key | ascii_downcase | contains("gameinfo") | not ) and
+      ( .value.runtime_arch == "aarch64" ) and
+      ( .value.url != null )
+    ))
+  | .[].value.url
+' "ports.json" | while read -r url; do
+  wget -P runtimes "$url"
+done


### PR DESCRIPTION
This was tested on muOS and does **NOT** work, the current problem is that it wants to use /tmp for a temp installation which is not made to store 1.3gb of files beside that everything seems to work fine

This is more of a idea of how it can be done, if i can figure out which folder and how to change the current /tmp problem then ill try to test it that way too

Another side effect is that installation now takes more than 10min ( maybe download something before hand like a simple Binary that just directly buffers something into fb that is just a loading screen )
I ofcourse dont know how "actions" handles that too, so this will probably break more then it should, but that wont be my problem