### PR TITLE
Adding swaymsg seat seat0 hide_cursor 0 into the mod_Rocknix to make 3d games not glitch

### DIFF
--- a/PortMaster/mod_ROCKNIX.txt
+++ b/PortMaster/mod_ROCKNIX.txt
@@ -27,5 +27,6 @@ GODOT_OPTS="--resolution ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT} -f"
 pm_platform_helper() {
     if [ -e "/usr/bin/portmaster_sway_fullscreen.sh" ]; then
         /usr/bin/portmaster_sway_fullscreen.sh "$(basename "$1")"
+        swaymsg seat seat0 hide_cursor 0
     fi
 }


### PR DESCRIPTION
This fixes the issue that sway makes the mouse cursor invisible after some time.

If the mouse cursor goes invisible it jumps back in the middle which completly breaks Minecraft and all of its Clones. Probably even more games are affected by this