### PR TITLE
Add patcher "questions" feature

### DIFF
--- a/PortMaster/utils/patcher.txt
+++ b/PortMaster/utils/patcher.txt
@@ -14,6 +14,6 @@ fi
 
 # Run the patcher with exported args
 $GPTOKEYB "$LOVE_GPTK" &
-$LOVE_RUN "$controlfolder/utils/patcher" -f "$PATCHER_FILE" -g "$PATCHER_GAME" -t "$PATCHER_TIME" "$CHANGELOG"
+$LOVE_RUN "$controlfolder/utils/patcher" -f "$PATCHER_FILE" -g "$PATCHER_GAME" -t "$PATCHER_TIME" "$CHANGELOG" -q "$PATCHER_QUESTIONS"
 
 pm_gptokeyb_finish


### PR DESCRIPTION
This PR adds a patching questions feature, you could ask the user for optional texture compression, deadzone sizes etc.

### Useage:
`export PATCHER_QUESTIONS=yourquestionfile.lua` in the launchscript before starting the patcher.

`questions.lua` example:
```
return {
    {
        id = "MODLOADER",
        question = "Would you like to install the game with a modloader?",
        options = {
            {"true", "Yes"},
            {"false", "No"}
        }
    },
    {
        id = "TEXCOMP",
        question = "Would you like to compress textures? (could help if the game won't start but might break things)",
        options = {
            {"yes", "Yes"},
            {"no", "No (only disable if you are on a device with atleast 2gb of ram)"}
        }
    }
}
```

The question IDs are forewareded to the patchscript as env vars.

### Preview:
<img width="647" height="489" alt="image" src="https://github.com/user-attachments/assets/4e84b5d1-c952-4168-bf97-1931960bd2d1" />
