### PR TITLE
fix regex to always extract CFW_NAME/VERSION on ArkOS AeUX

### DIFF
--- a/PortMaster/device_info.txt
+++ b/PortMaster/device_info.txt
@@ -62,8 +62,8 @@ if [ -f "/usr/share/plymouth/themes/text.plymouth" ]; then
         CFW_VERSION="Unknown"
 
     elif [[ $CFW_FFS == *"arkos"* ]]; then
-        CFW_NAME=$(echo "${CFW_INFO}" | sed -n 's/title=\(.*\) (\([0-9]\{8\}\))/\1/p' | cut -d' ' -f 1)
-        CFW_VERSION=$(echo "${CFW_INFO}" | sed -n 's/title=\(.*\) (\([0-9]\{8\}\)).*$/\2/p' | cut -d' ' -f 1)
+        CFW_NAME=$(echo "${CFW_INFO}" | sed -n 's/title=\(.*\) (\([0-9]\{8\}[^)]*\)).*$/\1/p' | cut -d' ' -f 1)
+        CFW_VERSION=$(echo "${CFW_INFO}" | sed -n 's/title=\(.*\) (\([0-9]\{8\}[^)]*\)).*$/\2/p' | cut -d' ' -f 1)
 
         if [[ $CFW_FFS == *"wummle"* ]]; then
             CFW_NAME="${CFW_NAME} wuMMLe"


### PR DESCRIPTION
On ArkOS AeUX, extraction of variables `CFW_NAME` and `CFW_VERSION` works _most of the time_. It only **fails on patch releases** like [this](https://github.com/AeolusUX/ArkOS-R3XS/releases/tag/ArkOS.V2.0.07312025-1), where `/usr/share/plymouth/themes/text.plymouth` contains `title=ArkOS 2.0 (07312025-1)(AeUX)`. As a result, `CFW_NAME` gets incorrectly set as  just ` AeUX`. Based on how this variable is used in the [ports repository](https://github.com/PortsMaster/PortMaster-New), up to 15 ports are broken.

I have tested the following _Ready to Run_/preowned ports to fail on ArkOS AeUX before my fix, and to work after it:
- [Quake 1](https://portmaster.games/detail.html?name=quake)
- [Rick Dangerous](https://portmaster.games/detail.html?name=rick.dangerous)
- [Rise of the Triad](https://portmaster.games/detail.html?name=rott): The Hunt Begins (Dark War complains about "Missing gamedata", as I don't own the required assets)
- [Steamworld Dig 2](https://portmaster.games/detail.html?name=steamworlddig2)
- [Steamworld Heist](https://portmaster.games/detail.html?name=steamworldheist)

No code changes to the ports themselves are required. I have also tested that my fix does not break any of them on ROCKNIX. Unfortunately, I lack assets to (or I am otherwise unable to install) the following ports that should also benefit:
- [Duke Nukem 3D - Alien World Order](https://portmaster.games/detail.html?name=duke3dawo)
- [Ion Fury](https://portmaster.games/detail.html?name=ionfury) (I actually own the required assets, but I can not find the port to install using ArkOS AeUX) 

In a [separate PR](https://github.com/PortsMaster/PortMaster-New/pull/2016) to the ports repository, I have fixed a number of other ports that require this change **AND** _some launching script changes_. If in doing so I have broken any Community Guidelines (either here or there) please accept my apologies and help me to learn.