### PR TITLE
Update PortMasterDialog.txt for RetroDECK IP check fix

### DIFF
--- a/PortMaster/PortMasterDialog.txt
+++ b/PortMaster/PortMasterDialog.txt
@@ -17,7 +17,7 @@ PM_PID=""
 export PYSDL2_DLL_PATH="/usr/lib"
 
 PortMasterIPCheck() {
-if command -v curl >/dev/null 2>&1; then
+  if command -v curl >/dev/null 2>&1; then
     curl -fsS https://raw.githubusercontent.com/PortsMaster/PortMaster-New/main/README.md 2>/dev/null | grep '## PortMaster'
   elif command -v ip >/dev/null 2>&1; then
     # Taken from original PortMaster.sh


### PR DESCRIPTION
RetroDECK does not have the ip command and fails so network checks need to use curl or wget. There could be a more failproof method, but this has been successful in my testing on SteamDeck.

To test run an autoinstall connected and disconnected from network and see what the finish messages state.