### PR TITLE
func.txt - pm_gptokeyb_finish - use SIGKILL

### DIFF
--- a/PortMaster/funcs.txt
+++ b/PortMaster/funcs.txt
@@ -148,8 +148,8 @@ pm_message() {
 
 
 pm_gptokeyb_finish() {
-    $ESUDO pkill -f gptokeyb
-    $ESUDO pkill -f gptokeyb2
+    $ESUDO pkill -9 -f gptokeyb
+    $ESUDO pkill -9 -f gptokeyb2
 }
 
 


### PR DESCRIPTION
`SIGTERM` is not sufficient in my testing.

After calling `pm_finish`: https://github.com/PortsMaster/PortMaster-GUI/blob/main/PortMaster/funcs.txt#L156

I am still getting `gptokeyb` processes left alive after exiting the game (not via `gptokeyb` exit hotkey):
```
S922X:~/roms/ports/PortMaster # ps aux | grep gptokeyb
root       23843  1.1  0.2  19880  5532 ?        Sl   10:07   0:00 /roms/ports/PortMaster/gptokeyb -1 nfs5.exe -c ./nfs5.gptk
root       24888  0.0  0.0   2980  1168 pts/0    S+   10:09   0:00 grep --color=auto gptokeyb
```

A little more testing:
```
// Does not work
pkill -f gptokeyb

// Does work
pkill -9 -f gptokeyb
```

I see examples of port launch scripts using `SIGKILL` to clean up `gptokeyb` processes.