### PR TITLE
Update SDL gamecontroller configuration handling for knulli xbox360 mode

### DIFF
--- a/PortMaster/knulli/control.txt
+++ b/PortMaster/knulli/control.txt
@@ -46,6 +46,9 @@ get_controls() {
   LOWRES="N"
 
   export SDL_GAMECONTROLLERCONFIG_FILE="/tmp/gamecontrollerdb.txt"
+  mv $SDL_GAMECONTROLLERCONFIG_FILE /tmp/gamecontrollerdb.tmp
+  grep 030000005e0400008e02000004010000 "$controlfolder/knulli/gamecontrollerdb.txt" >> $SDL_GAMECONTROLLERCONFIG_FILE
+  cat /tmp/gamecontrollerdb.tmp >> $SDL_GAMECONTROLLERCONFIG_FILE
 
   sdl_controllerconfig="$(< "${SDL_GAMECONTROLLERCONFIG_FILE}")"
 }


### PR DESCRIPTION
prepend xbox360 controller data to knulli generated gamecontrollerdb.txt to fix gptokeyb issues.  Tested in rg35xxh gladiator II, g350 on alpha and TSPS on alpha so far, info in Gptokeyb xbox mode testing thread
