### PR TITLE
Apply platform button mapping in fifo_control mode

### DIFF
--- a/PortMaster/pugwash
+++ b/PortMaster/pugwash
@@ -2064,6 +2064,12 @@ def main(argv):
                 with pm.enable_cancellable(False):
                     pm.hm = HarbourMaster(config, temp_dir=temp_dir, callback=pm)
 
+            if pm.hm is not None:
+                if pm.hm.platform.WANT_XBOX_FIX:
+                    pm.events.fix_xbox_mode()
+
+                pm.SWAP_BUTTONS = pm.hm.platform.WANT_SWAP_BUTTONS
+
             pm.do_fifo_control(config, argv[2:])
             pm.quit()
             return 0


### PR DESCRIPTION
The autoinstall confirm dialog said to press A but that wasn't working. B worked. This is what Claude found. It sounds plausible to me and the fix works on my device. But I don't know the code well enough to know if this is correct.

---

Claude's suggested PR message:

fix_xbox_mode() and SWAP_BUTTONS were only applied in run(), so the autoinstall dialog had incorrect button mapping on Nintendo-layout devices — pressing A did nothing and B confirmed the dialog instead.