### PR TITLE
Fix PortMaster ui refresh for UnofficialOS

### DIFF
--- a/PortMaster/PortMaster.sh
+++ b/PortMaster/PortMaster.sh
@@ -192,6 +192,9 @@ if [ -f "${controlfolder}/.emustation-refresh" ]; then
 elif [ -f "${controlfolder}/.weston-refresh" ]; then
   $ESUDO rm -f "${controlfolder}/.weston-refresh"
   $ESUDO systemctl restart ${UI_SERVICE}
+elif [ -f "${controlfolder}/.sway-refresh" ]; then
+  $ESUDO rm -f "${controlfolder}/.sway-refresh"
+  $ESUDO systemctl restart ${UI_SERVICE}
 elif [ -f "${controlfolder}/.emulationstation-refresh" ]; then
   $ESUDO rm -f "${controlfolder}/.emulationstation-refresh"
   $ESUDO systemctl restart emulationstation

--- a/PortMaster/pylibs/harbourmaster/platform.py
+++ b/PortMaster/pylibs/harbourmaster/platform.py
@@ -317,7 +317,7 @@ class PlatformGCD_PortMaster:
 
 
 class PlatformUOS(PlatformGCD_PortMaster, PlatformBase):
-    ES_NAME = os.environ["UI_SERVICE"].split()[0].replace(".service", "")
+    ES_NAME = os.environ.get("UI_SERVICE","emustation").split()[0].replace(".service", "")
 
     def gamelist_file(self):
         return self.hm.ports_dir / 'gamelist.xml'

--- a/PortMaster/pylibs/harbourmaster/platform.py
+++ b/PortMaster/pylibs/harbourmaster/platform.py
@@ -317,7 +317,7 @@ class PlatformGCD_PortMaster:
 
 
 class PlatformUOS(PlatformGCD_PortMaster, PlatformBase):
-    ES_NAME = 'emustation'
+    ES_NAME = os.environ["UI_SERVICE"].split()[0].replace(".service", "")
 
     def gamelist_file(self):
         return self.hm.ports_dir / 'gamelist.xml'


### PR DESCRIPTION
- changed hardcoded emustation service in platform.py, now it gets pulled from env to properly handle emustation/weston/sway .service
- add sway refresh if block in portmaster.sh