### PR TITLE
Allow custom fail messages in patchscripts

### DIFF
--- a/PortMaster/utils/patcher/main.lua
+++ b/PortMaster/utils/patcher/main.lua
@@ -20,6 +20,7 @@ local gameName = "the game"
 local patchTime = "5 minutes"
 local isNews = false
 local patchScript = "patch_script.sh"  -- Default patch script
+local patchFailedMessage = "Patching failed! Please go to the PortMaster Discord for help."
 local visibleOptionCount = 3
 
 -- Variables
@@ -129,6 +130,14 @@ end
 function readPatchOutput()
     local line = patchChannel:pop()  -- Attempt to read output
     if line then
+        -- Patch scripts can override the failure dialog message by emitting
+        -- "PATCH_FAIL_MSG:<message>" before "Patching process failed!".
+        local overrideMsg = line:match("^PATCH_FAIL_MSG:(.*)")
+        if overrideMsg then
+            patchFailedMessage = overrideMsg
+            return
+        end
+
         local wrappedLines = wrapText(line, 62)
         for _, wrappedLine in ipairs(wrappedLines) do
             table.insert(patchOutput, wrappedLine)
@@ -258,7 +267,7 @@ end
 
 -- Function to show patch failed dialog
 function PatchFailed()
-    Talkies.say("Cybion", "Patching failed! Please go to the PortMaster Discord for help.", {
+    Talkies.say("Cybion", patchFailedMessage, {
         thickness = 2,
         image = cybion,
         oncomplete = function()


### PR DESCRIPTION
The default is still `"Patching failed! Please go to the PortMaster Discord for help."` however with this addition, patchscripts can override with their own failure messages. This is more verbose for the end user and more helpful for the ecosystem with things outside of PortMaster that make use of the patcher gui, and also helpful in not directing everything that uses it to the PortMaster Discord.

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/806fb9a1-f597-44c6-aa72-c4af9899f651" />

In practice I tested with the following:

```bash
emit_fail_msg() {
    echo "PATCH_FAIL_MSG:$1" >&3
    echo "$1"
}

if [ -z "$VCDIFF" ] || [ ! -x "$VCDIFF" ]; then
    emit_fail_msg "Patching failed: vcdiff tool missing. Try reinstalling the port."
    return 1
fi
```

This in turn shows both the error to the gui dialog and provides a clean log text file:
```
GAMEDIR is set to: /roms/ports/zelda-ladxhd/data
Preparing system...
Patching failed: vcdiff tool missing. Try reinstalling the port.
Patching process failed!
```

Thank you for your efforts and for keeping your tools available for all.