### PR TITLE
Add MiniLoong CFW support (device_info probe + mod_Loong.txt)

### DIFF
--- a/PortMaster/device_info.txt
+++ b/PortMaster/device_info.txt
@@ -49,7 +49,11 @@ fi
 CFW_NAME="Unknown"
 CFW_VERSION="Unknown"
 
-if [ -f "/usr/share/plymouth/themes/text.plymouth" ]; then
+if [ -f "/loong/loong_version" ]; then
+    CFW_NAME="Loong"
+    CFW_VERSION=$(cat /loong/loong_version 2>/dev/null | grep -o '"verShow"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4)
+    [ -z "$CFW_VERSION" ] && CFW_VERSION="Unknown"
+elif [ -f "/usr/share/plymouth/themes/text.plymouth" ]; then
     CFW_INFO=$(grep "title=" "/usr/share/plymouth/themes/text.plymouth")
     CFW_FFS=$(grep -a "title=" "/usr/share/plymouth/themes/text.plymouth" | cut -d'=' -f 2- | tr -cd 'a-zA-Z' | tr '[:upper:]' '[:lower:]')
 

--- a/PortMaster/mod_Loong.txt
+++ b/PortMaster/mod_Loong.txt
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: MIT
+#
+
+## Modular - Loong
+#
+# A modular file that is sourced for specific script lines required by ports running on MiniLoong.
+#
+# usage `[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"`
+
+# Set virtual screen
+CUR_TTY="/dev/fd/1"
+
+# Use for Godot 2
+GODOT2_OPTS="-r ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT} -f"
+
+# Use for Godot 3+
+GODOT_OPTS="--resolution ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT} -f"
+
+export directory="mnt/sdcard/roms"
+
+pm_platform_helper() {
+    if [ -e "$PM_PIPE" ]; then
+        PortMasterDialogExit
+    fi
+
+    # DO SOMETHING HERE
+    printf ""
+}


### PR DESCRIPTION
## Summary

Adds support for **MiniLoong**, a Loongson-based handheld CFW, by following the same two-file pattern used by every existing CFW in the repo (Batocera, knulli, muOS, TrimUI, ROCKNIX, etc.):

1. **`PortMaster/device_info.txt`** — probe `/loong/loong_version` (a JSON-style version file shipped by the MiniLoong firmware) and set `$CFW_NAME=Loong` / `$CFW_VERSION`.
2. **`PortMaster/mod_Loong.txt`** — CFW-specific tweaks loaded via the existing `[ -f "$controlfolder/mod_$CFW_NAME.txt" ] && source ...` convention. Structurally identical to `mod_TrimUI.txt` / `mod_muOS.txt` (same `CUR_TTY`, Godot opts, `pm_platform_helper` stub) plus one MiniLoong-specific override.

## The MiniLoong-specific override

```bash
export directory="mnt/sdcard/roms"
```

MiniLoong mounts the SD card at `/mnt/sdcard/` rather than `/roms/`. Other CFWs with non-standard mounts (e.g. TrimUI at `/mnt/SDCARD`) rely on a system-level `/roms` → `<real mount>` symlink. MiniLoong's firmware does not currently provide one, so ports need this `$directory` override to resolve `$GAMEDIR` correctly.

Scope is contained: the override only runs when `$CFW_NAME == "Loong"`, which only triggers when `/loong/loong_version` exists (a MiniLoong-exclusive path). No other CFW is affected.

## Why not patch control.txt to be mount-agnostic instead

Considered and dropped. Generalizing the `$directory` derivation in `control.txt` is the more principled fix, but it touches core code used by every CFW and I cannot verify behavior on ArkOS/JELOS/ROCKNIX/muOS/TrimUI etc. without access to those devices. Until that broader testing can be done, the conservative path is to keep the change CFW-local.

## Test plan

- [x] `bash -n PortMaster/device_info.txt PortMaster/mod_Loong.txt`
- [x] Verified on a MiniLoong device: `CFW_NAME=Loong`, `CFW_VERSION` populated from `verShow`, `mod_Loong.txt` sourced by the existing convention, ports launch with `$GAMEDIR=/mnt/sdcard/roms/ports/<port>`.
- [x] No diff to `control.txt` or any non-Loong CFW file, so no risk of regression elsewhere.

## Commits

- `device_info: detect MiniLoong CFW via /loong/loong_version`
- `mod_Loong: add MiniLoong CFW-specific overrides`