### PR TITLE
Fix untar error for knulli

### DIFF
--- a/tools/makeself-header.sh
+++ b/tools/makeself-header.sh
@@ -483,9 +483,9 @@ MS_Decompress()
 UnTAR()
 {
     if test x"\$quiet" = xn; then
-		tar \$1vf - $UNTAR_EXTRA 2>&1 || { echo " ... Extraction failed." >&2; kill -15 \$$; }
+		tar \$1vf - --no-same-owner $UNTAR_EXTRA 2>&1 || { echo " ... Extraction failed." >&2; kill -15 \$$; }
     else
-		tar \$1f - $UNTAR_EXTRA 2>&1 || { echo Extraction failed. >&2; kill -15 \$$; }
+		tar \$1f - --no-same-owner $UNTAR_EXTRA 2>&1 || { echo Extraction failed. >&2; kill -15 \$$; }
     fi
 }
 


### PR DESCRIPTION
This would be good for further testing in a future beta, but it should fix existing error reports we've been having for knulli due to moving  tmp from /tmp to the roms partition which is typically exfat

Added --no-same-owner option to tar command see todo in discord for the troubleshooting details
