### PR TITLE
add NextUI detection for TrimUI OS warnings

### DIFF
--- a/PortMaster/pylibs/pugscene.py
+++ b/PortMaster/pylibs/pugscene.py
@@ -42,7 +42,13 @@ def get_startup_warnings(device_info):
     except (OSError, UnicodeDecodeError):
         pass
 
-    # TODO: add checks for NextUI, PakUI when we have unique markers
+    try:
+        if 'NextUI' in Path('/mnt/SDCARD/.system/version.txt').read_text():
+            warnings.append(('nextui', _('NextUI is not supported by PortMaster.'), firmware_suggestion))
+    except (OSError, UnicodeDecodeError):
+        pass
+
+    # TODO: add a check for PakUI when we have a unique marker
 
     # Generic catch-all for TrimUI-based OSes we can't identify specifically
     if not warnings and Path('/etc/trimui_device.txt').exists():


### PR DESCRIPTION
This path likely works for MinUI and possibly PakUI detection as well, but I do not have devices with either right now to test.

Confirmed works on NextUI.