### PR TITLE
TrimUI: guard samefile() against missing target on first port install

### DIFF
--- a/PortMaster/pylibs/harbourmaster/platform.py
+++ b/PortMaster/pylibs/harbourmaster/platform.py
@@ -1073,7 +1073,7 @@ class PlatformTrimUI(PlatformBase):
 
         if port_mode == 'roms':
             target_file = ROM_SCRIPT_DIR / (port_script.name)
-            if not os.path.samefile(port_script, target_file):
+            if not target_file.exists() or not os.path.samefile(port_script, target_file):
                 logger.debug(f"Copying {str(port_script)} to {str(target_file)}")
                 shutil.copy(port_script, target_file)
             else:


### PR DESCRIPTION
`os.path.samefile()` stats both paths passed to it; on first-time port installs the `target` may not yet exist, resulting in a `FileNotFoundError` which aborts the installation.

Short-circuit this check by checking that the `target` exists before executing the `os.path.samefile()` comparison. If the target doesn't exist then we flow directly into the code below (as if the `samefile` check failed.)