### PR TITLE
Add check and fix for broken libMali (GLES) symlinks on dArkOS

### DIFF
--- a/PortMaster/mod_dArkOS.txt
+++ b/PortMaster/mod_dArkOS.txt
@@ -17,6 +17,28 @@ $ESUDO chmod 755 /run/user/$UID
 $ESUDO chmod 755 /run/user/$UID/pulse
 sleep 0.3
 
+if [ "$(readlink /usr/lib/aarch64-linux-gnu/libEGL.so.1)" != "libMali.so" ] || [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1.1.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv1_CM.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1.1.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so.2
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so.2.0.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so.2.1.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv3.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv3.so.3
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libgbm.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libgbm.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libgbm.so.1.0.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libmali.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libmali.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libGLdispatch.so.0.0.0 /usr/lib/aarch64-linux-gnu/libGLdispatch.so
+fi
+
 pm_platform_helper() {
     # DO SOMETHING HERE
     printf ""

--- a/PortMaster/mod_dArkOSRE.txt
+++ b/PortMaster/mod_dArkOSRE.txt
@@ -17,6 +17,28 @@ $ESUDO chmod 755 /run/user/$UID
 $ESUDO chmod 755 /run/user/$UID/pulse
 sleep 0.3
 
+if [ "$(readlink /usr/lib/aarch64-linux-gnu/libEGL.so.1)" != "libMali.so" ] || [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1.1.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv1_CM.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1.1.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so.2
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so.2.0.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv2.so.2.1.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv3.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libGLESv3.so.3
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libgbm.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libgbm.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libgbm.so.1.0.0
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libmali.so
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libmali.so.1
+  sudo ln -sfv /usr/lib/aarch64-linux-gnu/libGLdispatch.so.0.0.0 /usr/lib/aarch64-linux-gnu/libGLdispatch.so
+fi
+
 pm_platform_helper() {
     # DO SOMETHING HERE
     printf ""


### PR DESCRIPTION
Add check and fix for broken libMali (GLES) symlinks on dArkOS
Some files/symlinks in the system that should be pointing to libMali.so are either linked to another file, have libMali misspelled or wrong case, or don't exist causing native GLES ports to not launch.

Some native GLES ports known affected:
Quake 3
Return to Castle Wolfenstein
Re-volt
