### PR TITLE
Uconsole Fix detection

### DIFF
--- a/PortMaster/control.txt
+++ b/PortMaster/control.txt
@@ -151,11 +151,10 @@ get_controls() {
 
   export SDL_GAMECONTROLLERCONFIG_FILE="/tmp/gamecontrollerdb.txt"
 
-  # Spit the controller of the device our heuristics found (if it did).
   if [[ ! -z ${DEVICE} ]]; then
     grep "${SDLDBUSERFILE}" -e "${DEVICE}" > /tmp/gamecontrollerdb.txt
   else
-    echo "" > /tmp/gamecontrollerdb.txt
+    cp "$controlfolder/gamecontrollerdb.txt" /tmp/gamecontrollerdb.txt
   fi
 
   if [[ -f "${HOME}/.config/emulationstation/es_input.cfg" ]]; then

--- a/PortMaster/gamecontrollerdb.txt
+++ b/PortMaster/gamecontrollerdb.txt
@@ -1795,4 +1795,4 @@ xinput,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,
 050000005e040000130b0000df870001,Xbox Series X Controller,a:b0,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,leftstick:b6,lefttrigger:a2,leftx:a0,lefty:a1,misc1:b10,rightshoulder:b5,rightstick:b7,righttrigger:a5,rightx:a3,righty:a4,start:b9,x:b2,y:b3,platform:iOS,
 050000005e040000130b0000ff870001,Xbox Series X Controller,a:b0,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b9,leftshoulder:b4,leftstick:b6,lefttrigger:a2,leftx:a0,lefty:a1,misc1:b11,rightshoulder:b5,rightstick:b7,righttrigger:a5,rightx:a3,righty:a4,start:b10,x:b2,y:b3,platform:iOS,
 # uConsole
-03000000af1e00002400000010010000,ClockworkPI uConsole,a:b1,b:b2,x:b0,y:b3,back:b8,start:b9,leftx:a0,lefty:a1,platform:Linux, 
+030000fdaf1e00002400000010010000,ClockworkPI uConsole,a:b1,b:b2,x:b0,y:b3,back:b8,start:b9,leftdp:h0.8,rightdp:h0.2,updp:h0.1,downdp:h0.4,platform:Linux,


### PR DESCRIPTION
Bug: When DEVICE cannot be detected (device=unknown), control.txt creates an empty /tmp/gamecontrollerdb.txt. As a result SDL loses all controller mappings and SDL_IsGameController() returns false even for controllers present in gamecontrollerdb.txt (e.g. ClockworkPI uConsole on Raspberry Pi 5 OS Debian Trixie 13).

Expected behavior: If no specific device is detected, fall back to the bundled gamecontrollerdb.txt instead of an empty file.

Result: SDL can still recognize all standard controllers while keeping existing behavior for known devices.

There was also an incorrect ID for Uconsole that have been fixed.

There's still need to resolve the Device: Unknown issue. But I don't know how to fix it.

Current log after fixes:
lesha@clockworkpi:~ $ sudo /roms/ports/PortMaster.sh
/roms/ports/PortMaster/control.txt: строка 72: [: sudo: ожидается бинарный оператор
tee: '/root/device_info_Debian GNU/Linux_Pi.txt': Нет такого файла или каталога
# Pi - Debian GNU/Linux
```bash
DEVICE_INFO_VERSION=0.1.15
PM_VERSION=2026.06.23-0015
CFW_NAME=Debian GNU/Linux
CFW_VERSION=13
CFW_GLIBC=241
DEVICE_NAME=Pi
DEVICE_CPU=Cortex-A76
DEVICE_ARCH=aarch64
DEVICE_RAM=8
DEVICE_HAS_ARMHF="N"
DEVICE_HAS_AARCH64="Y"
DEVICE_HAS_X86="N"
DEVICE_HAS_X86_64="N"
DISPLAY_WIDTH=1280
DISPLAY_HEIGHT=720
DISPLAY_ORIENTATION=0
ASPECT_X=16
ASPECT_Y=9
ANALOG_STICKS=2
```
[ALSOFT] (EE) Failed to connect PipeWire event context (errno: 112)
2026-07-21 12:59:01.662 | DEBUG    | harbourmaster.config:<module>:194 - HM_DEFAULT_TOOLS_DIR:   /roms/ports
2026-07-21 12:59:01.663 | DEBUG    | harbourmaster.config:<module>:195 - HM_DEFAULT_PORTS_DIR:   /roms/ports
2026-07-21 12:59:01.663 | DEBUG    | harbourmaster.config:<module>:196 - HM_DEFAULT_SCRIPTS_DIR: /roms/ports
Attempting to delete file at path: /roms/ports/PortMaster/utils/pmsplash/stopsplash
File 'stopsplash' deleted successfully.
0: 1
{'name': 'Debian GNU/Linux', 'version': '13 (trixie)', 'device': 'unknown', 'resolution': (640, 480), 'analogsticks': 2, 'cpu': 'unknown', 'capabilities': ['opengl', 'power', 'aarch64', 'restore', '4:3', '640x480', 'Debian GNU/Linux', 'unknown', 'analog_0', 'analog_1', 'analog_2', '1gb', '2gb', '4gb', '8gb', 'ru_RU'], 'primary_arch': 'aarch64', 'ram': 8192, 'glibc': '2.41'}
