### PR TITLE
Remove readlink check from if statement

### DIFF
--- a/PortMaster/mod_dArkOS.txt
+++ b/PortMaster/mod_dArkOS.txt
@@ -17,7 +17,7 @@ $ESUDO chmod 755 /run/user/$UID
 $ESUDO chmod 755 /run/user/$UID/pulse
 sleep 0.3
 
-if [ "$(readlink /usr/lib/aarch64-linux-gnu/libEGL.so.1)" != "libMali.so" ] || [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
+if [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0

--- a/PortMaster/mod_dArkOSRE.txt
+++ b/PortMaster/mod_dArkOSRE.txt
@@ -17,7 +17,7 @@ $ESUDO chmod 755 /run/user/$UID
 $ESUDO chmod 755 /run/user/$UID/pulse
 sleep 0.3
 
-if [ "$(readlink /usr/lib/aarch64-linux-gnu/libEGL.so.1)" != "libMali.so" ] || [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
+if [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0


### PR DESCRIPTION
The readlink check that was intended to verify that libEGL.so.1 was not symlinked to libMali.so before running was somehow always returning 'true' which resulted in the libMali symlink fix running every single time.  I've simplified the check to only verify if libGLdispatch.so is missing so that it ensures it only runs the fix once.