### PR TITLE
Mod_*arkos.txt fixes to remove incomplete pm_platform_helper

### DIFF
--- a/PortMaster/mod_ArkOS wuMMLe.txt
+++ b/PortMaster/mod_ArkOS wuMMLe.txt
@@ -16,8 +16,3 @@ $ESUDO chown $UID /run/user/$UID/pulse
 $ESUDO chmod 755 /run/user/$UID
 $ESUDO chmod 755 /run/user/$UID/pulse
 sleep 0.3
-
-pm_platform_helper() {
-    # DO SOMETHING HERE
-    printf ""
-}

--- a/PortMaster/mod_ArkOS.txt
+++ b/PortMaster/mod_ArkOS.txt
@@ -16,8 +16,3 @@ $ESUDO chown $UID /run/user/$UID/pulse
 $ESUDO chmod 755 /run/user/$UID
 $ESUDO chmod 755 /run/user/$UID/pulse
 sleep 0.3
-
-pm_platform_helper() {
-    # DO SOMETHING HERE
-    printf ""
-}

--- a/PortMaster/mod_dArkOS.txt
+++ b/PortMaster/mod_dArkOS.txt
@@ -38,8 +38,3 @@ if [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libmali.so.1
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libGLdispatch.so.0.0.0 /usr/lib/aarch64-linux-gnu/libGLdispatch.so
 fi
-
-pm_platform_helper() {
-    # DO SOMETHING HERE
-    printf ""
-}

--- a/PortMaster/mod_dArkOSRE.txt
+++ b/PortMaster/mod_dArkOSRE.txt
@@ -38,8 +38,3 @@ if [ ! -e /usr/lib/aarch64-linux-gnu/libGLdispatch.so ]; then
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libmali.so.1
   sudo ln -sfv /usr/lib/aarch64-linux-gnu/libGLdispatch.so.0.0.0 /usr/lib/aarch64-linux-gnu/libGLdispatch.so
 fi
-
-pm_platform_helper() {
-    # DO SOMETHING HERE
-    printf ""
-}


### PR DESCRIPTION
Removing pm_platform_helper from mod files so that funcs.txt default takes over, tested and it fixes flashing pm_message dialogs at start of race into space for example