### PR TITLE
Use mkdir -p to create portmaster directory in /dev/shm

### DIFF
--- a/PortMaster/PortMasterDialog.txt
+++ b/PortMaster/PortMasterDialog.txt
@@ -8,7 +8,7 @@ if [ ! -z "$PM_PIPE" ]; then
 fi
 
 if [ ! -d "/dev/shm/portmaster" ]; then
-  $ESUDO mkdir /dev/shm/portmaster
+  $ESUDO mkdir -p /dev/shm/portmaster
 else
   $ESUDO rm -f /dev/shm/portmaster/pm_*
 fi


### PR DESCRIPTION
on Spruce /dev/shm doesn't exist so mkdir /dev/shm/portmaster failed and broke pm_message.  Open to ideas if there are any drawbacks to this, but i would hope every mkdir we support can handle a -p argument =)