### PR TITLE
I made an oopsie: detect spruce platform is ACTUALLY being used

### DIFF
--- a/PortMaster/pylibs/harbourmaster/hardware.py
+++ b/PortMaster/pylibs/harbourmaster/hardware.py
@@ -548,6 +548,10 @@ def new_device_info():
 
     info['device'] = info['device'].lower().replace(' ', '-')
 
+    if Path('/mnt/SDCARD/spruce').is_dir():
+        info['name'] = 'spruce'
+        info['version'] = safe_cat('/mnt/SDCARD/spruce/spruce').strip()
+
     info.setdefault('name', 'Unknown')
     info.setdefault('version', '0.0.0')
 

--- a/PortMaster/pylibs/harbourmaster/platform.py
+++ b/PortMaster/pylibs/harbourmaster/platform.py
@@ -1275,8 +1275,7 @@ class PlatformMiyoo(PlatformBase):
 
 
 class PlatformSpruce(PlatformBase):
-    # spruce sets SDL_GAMECONTROLLERCONFIG per pad itself.
-    WANT_XBOX_FIX = False
+    WANT_XBOX_FIX = True
 
     def first_run(self):
         self.portmaster_install([])


### PR DESCRIPTION
PlatformSpruce was added in #337 but never gets selected. harbour.py picks the
platform from hardware.py's device_info(), which has no spruce check, so devices
match trimui or miyoo instead. spruce runs on top of the stock firmware, so the
check has to come after those rather than before.

Also sets WANT_XBOX_FIX to true. spruce gives pugwash a positional pad on every
device, so it needs the same A/B correction the other platforms use.

Tested on a TrimUI Smart Pro S, an Anbernic RG28XX and a Powkiddy RGB30.

The diff is exactly what our launch-time patches do, so merging it lets us drop those later, and nothing breaks in the meantime if it sits unmerged. And the WANT_XBOX_FIX half reverses a value from our own previous PR.... my bad....
